### PR TITLE
Remove credentials after cleanup

### DIFF
--- a/frieza-clean/cleanup.js
+++ b/frieza-clean/cleanup.js
@@ -6,6 +6,7 @@ const setup = require('./lib/frieza');
   try {
     const timeout = core.getInput('clean_timeout');
     await setup.cleanAccount(timeout)
+    await setup.removeCredentials()
 } catch (error) {
     core.setFailed(error.message);
 }

--- a/frieza-clean/lib/frieza.js
+++ b/frieza-clean/lib/frieza.js
@@ -92,6 +92,11 @@ async function addCredentials(access_key, secret_key, region) {
     await exec.exec('frieza', ['profile', 'new', 'outscale_oapi', `--region=${region}`, `--ak=${access_key}`, `--sk=${secret_key}`, default_profile_name]);
 }
 
+async function removeCredentials() {
+    core.debug(`Remove credentials of frieza`);
+    await exec.exec('frieza', ['profile', 'remove', default_profile_name]);
+}
+
 async function makeSnapshot() {
     core.debug(`Make a snapshot`);
     await exec.exec('frieza', ['snapshot', 'new', default_snapshot_name, default_profile_name]);
@@ -105,5 +110,6 @@ async function cleanAccount(timeout) {
 
 exports.makeSnapshot = makeSnapshot;
 exports.addCredentials = addCredentials;
+exports.removeCredentials = removeCredentials
 exports.downloadBinary = downloadBinary;
 exports.cleanAccount = cleanAccount;


### PR DESCRIPTION
In case of non ephemeral runners, the credentials was not removed and we could not run a second times