### PR TITLE
✨ feat: multi-provider cleaning

### DIFF
--- a/frieza-clean/action.yml
+++ b/frieza-clean/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: Ignore cleanup failures, continue to next step if possible.
     required: false
     default: 'false'
+  providers:
+    description: 'List of providers (comma-separated: outscale_oapi,outscale_oos,outscale_oks,...).'
+    required: false
+    default: 'outscale_oapi'
 runs:
   using: 'node20'
   main: 'index.js'

--- a/frieza-clean/index.js
+++ b/frieza-clean/index.js
@@ -9,13 +9,16 @@ const setup = require('./lib/frieza');
     const region = core.getInput('region')
     const release = core.getInput('release');
 
+    const providersInput = core.getInput('providers');
+    const providers = providersInput.split(',').map(p => p.trim()).filter(p => p !== '');
+    
     // Binary
     const pathToCLI = await setup.downloadBinary(release)
     core.debug(`Add ${pathToCLI} to PATH`)
     core.addPath(pathToCLI);
 
     // Credentials
-    await setup.addCredentials(access_key, secret_key, region)
+    await setup.addCredentials(access_key, secret_key, region, providers)
 
     // Snapshot
     await setup.makeSnapshot()

--- a/frieza-clean/lib/frieza.js
+++ b/frieza-clean/lib/frieza.js
@@ -96,9 +96,27 @@ function mapOS(os) {
     return mappings[os] || os;
 }
 
-async function addCredentials(access_key, secret_key, region) {
+async function addCredentials(access_key, secret_key, region, providers) {
     core.debug(`Add credentials to frieza`);
-    await exec.exec('frieza', ['profile', 'new', 'outscale_oapi', `--region=${region}`, `--ak=${access_key}`, `--sk=${secret_key}`, default_profile_name]);
+
+    await exec.exec('frieza', [
+        'profile',
+        'new',
+        providers[0],
+        `--region=${region}`,
+        `--ak=${access_key}`,
+        `--sk=${secret_key}`,
+        default_profile_name,
+    ]);
+
+    for (let i = 1; i < providers.length; i++) {
+        await exec.exec('frieza', [
+            'profile',
+            'add-provider',
+            providers[i],
+            default_profile_name,
+        ]);
+    }
 }
 
 async function removeCredentials() {


### PR DESCRIPTION
This PR adds support for multi-provider cleaning by adding an optional `providers` input which defaults to `outscale_oapi` to be backward compatible.

Related to https://github.com/outscale/frieza/pull/369
